### PR TITLE
Add `-g` flag to compilation when compiling with `debug = true` in Cargo Profile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,7 @@ impl Config {
     fn gcc(&self) -> Command {
         let target = getenv_unwrap("TARGET");
         let opt_level = getenv_unwrap("OPT_LEVEL");
+        let debug = getenv_unwrap("DEBUG");
         let profile = getenv_unwrap("PROFILE");
         println!("{} {}", profile, opt_level);
 
@@ -180,6 +181,10 @@ impl Config {
         cmd.arg("-c");
         // cmd.arg("-ffunction-sections").arg("-fdata-sections");
         cmd.args(&cflags());
+
+        if debug == "true" {
+            cmd.arg("-g");
+        }
 
         if target.contains("-ios") {
             cmd.args(&ios_flags(&target));


### PR DESCRIPTION
This allows the c sources to be compiled with debugging flag when making a dev rust build.
